### PR TITLE
Revert "don't show share menu item for top level folders"

### DIFF
--- a/shell_integration/nautilus/syncstate.py
+++ b/shell_integration/nautilus/syncstate.py
@@ -157,18 +157,13 @@ class MenuExtension(GObject.GObject, Nautilus.MenuProvider):
         # internal or external file?!
         syncedFile = False
         for reg_path in socketConnect.registered_paths:
-            topLevelFolder=False
             filename = get_local_path(file.get_uri())
             #check if its a folder (ends with an /), if yes add a "/" otherwise it will not find the entry in the table
             if os.path.isdir(filename+"/"):
                 filename=filename+"/"
-                #check if toplevel folder, we need to ignore those as they cannot be shared
-                if filename.count("/") < (reg_path.count("/")+2):
-                    topLevelFolder=True
             # only show the menu extension if the file is synced and the sync
             # status is ok. Not for ignored files etc.
-            # ignore top level folders
-            if filename.startswith(reg_path) and topLevelFolder == False and socketConnect.nautilusVFSFile_table[filename]['state'] == 'OK':
+            if filename.startswith(reg_path) and socketConnect.nautilusVFSFile_table[filename]['state'] == 'OK':
                 syncedFile = True
 
         # if it is neither in a synced folder or is a directory


### PR DESCRIPTION
fixes the unicode issue #3753 
I don't know much CPP and Qt  but after some google research I found this http://wiki.qt.io/Strings_and_encodings_in_Qt 
it does mention ````trUtf8()```` that has done the trick for me on Linux with Gnome 3.16.
Haven't tested it on other systems